### PR TITLE
Adds FSock parameter to event handler functions

### DIFF
--- a/fsock.go
+++ b/fsock.go
@@ -110,7 +110,7 @@ type FSock struct {
 	conn               net.Conn
 	buffer             *bufio.Reader
 	fsaddress, fspaswd string
-	eventHandlers      map[string][]func(string, *FSock)
+	eventHandlers      map[string][]func(string)
 	eventFilters       map[string]string
 	apiChan, cmdChan   chan string
 	reconnects         int
@@ -346,7 +346,7 @@ func (self *FSock) dispatchEvent(event string) {
 		if _, hasHandlers := self.eventHandlers[handleName]; hasHandlers {
 			// We have handlers, dispatch to all of them
 			for _, handlerFunc := range self.eventHandlers[handleName] {
-				go handlerFunc(event, self)
+				go handlerFunc(event)
 				return
 			}
 		}
@@ -354,7 +354,7 @@ func (self *FSock) dispatchEvent(event string) {
 }
 
 // Connects to FS and starts buffering input
-func NewFSock(fsaddr, fspaswd string, reconnects int, eventHandlers map[string][]func(string, *FSock), eventFilters map[string]string, l *syslog.Writer) (*FSock, error) {
+func NewFSock(fsaddr, fspaswd string, reconnects int, eventHandlers map[string][]func(string), eventFilters map[string]string, l *syslog.Writer) (*FSock, error) {
 	fsock := FSock{fsaddress: fsaddr, fspaswd: fspaswd, eventHandlers: eventHandlers, eventFilters: eventFilters, reconnects: reconnects, logger: l}
 	fsock.apiChan = make(chan string) // Init apichan so we can use it to pass api replies
 	fsock.cmdChan = make(chan string)
@@ -370,7 +370,7 @@ func NewFSock(fsaddr, fspaswd string, reconnects int, eventHandlers map[string][
 type FSockPool struct {
 	fsAddr, fsPasswd string
 	reconnects       int
-	eventHandlers    map[string][]func(string, *FSock)
+	eventHandlers    map[string][]func(string)
 	eventFilters     map[string]string
 	readEvents       bool // Fork reading events when creating the socket
 	logger           *syslog.Writer
@@ -400,7 +400,7 @@ func (self *FSockPool) PushFSock(fsk *FSock) {
 
 // Instantiates a new FSockPool
 func NewFSockPool(maxFSocks int, readEvents bool,
-	fsaddr, fspasswd string, reconnects int, eventHandlers map[string][]func(string, *FSock), eventFilters map[string]string, l *syslog.Writer) (*FSockPool, error) {
+	fsaddr, fspasswd string, reconnects int, eventHandlers map[string][]func(string), eventFilters map[string]string, l *syslog.Writer) (*FSockPool, error) {
 	pool := &FSockPool{fsAddr: fsaddr, fsPasswd: fspasswd, reconnects: reconnects, eventHandlers: eventHandlers, eventFilters: eventFilters, readEvents: readEvents, logger: l}
 	pool.fSocks = make(chan *FSock, maxFSocks)
 	for i := 0; i < maxFSocks; i++ {


### PR DESCRIPTION
- Fixes bug where an ALL event handler is called even if another handler matches Event-Name. 
- Fixes bug where ReadEvents() always dispatchesEvent() if the body isnt empty, even if the event is an API or Command response.
- Adds FSock parameter to event handler call backs so that event handlers can control Freeswitch.

I realise this breaks the interface for event handler functions, but couldn't think of another way of accessing the FSock connection from the event handler function.

We often have to handle events by sending another command into Freeswitch in order to control the call flow.
