### PR TITLE
Fixes an edge case, when the list length is exactly 5 (single one-legged call)

### DIFF
--- a/fsock.go
+++ b/fsock.go
@@ -169,7 +169,7 @@ func FSEventStrToMap(fsevstr string, headers []string) map[string]string {
 func MapChanData(chanInfoStr string) []map[string]string {
 	chansInfoMap := make([]map[string]string, 0)
 	spltChanInfo := strings.Split(chanInfoStr, "\n")
-	if len(spltChanInfo) <= 5 {
+	if len(spltChanInfo) < 5 {
 		return chansInfoMap
 	}
 	hdrs := strings.Split(spltChanInfo[0], ",")


### PR DESCRIPTION
In case of a single conference call the list generated by `show channels` contains only one channel and is exactly 5 lines in length.

Without this fix, the channel list is not parsed and instead an empty slice is returned.
See https://github.com/cgrates/cgrates/pull/309