### PR TITLE
Handle ECONNRESET error to trigger reconnect in readHeaders

### DIFF
--- a/fsock.go
+++ b/fsock.go
@@ -114,9 +114,11 @@ func (fs *FSock) handleConnectionError(connErr chan error) {
 	defer func() {
 		// If there's no designated stopError channel, log the error.
 		if fs.stopError == nil {
-			fs.logger.Err(fmt.Sprintf(
-				"<FSock> Error encountered while reading events (connection index: %d): %v",
-				fs.connIdx, err))
+			if err != nil {
+				fs.logger.Err(fmt.Sprintf(
+					"<FSock> Error encountered while reading events (connection index: %d): %v",
+					fs.connIdx, err))
+			}
 			return
 		}
 		// Otherwise, signal on the stopError channel.


### PR DESCRIPTION
Previously, all OpErrors were considered intentional and signaled a
graceful shutdown, ignoring 'connection reset by peer' errors wrapped
within OpErrors. This prevented attempts to reconnect to FreeSWITCH.

syscall.ECONNRESET is now also changed to io.EOF before sending it over
to the conn err handler, making sure that a reconnect is triggered.

A test was added to make sure we account for this issue in the future.